### PR TITLE
Pull in Zig/solution_1/Dockerfile from upstream

### DIFF
--- a/PrimeZig/solution_1/Dockerfile
+++ b/PrimeZig/solution_1/Dockerfile
@@ -1,6 +1,16 @@
-FROM archlinux:base
+FROM debian:buster-slim as builder
 
-RUN pacman --noconfirm -Sy zig
+RUN apt-get update && \
+    apt-get install -y curl xz-utils
+
+WORKDIR /deps
+RUN curl https://ziglang.org/download/0.8.0/zig-linux-"$(uname -m)"-0.8.0.tar.xz  -O && \
+    tar xf zig-linux-"$(uname -m)"-0.8.0.tar.xz && \
+    mv zig-linux-"$(uname -m)"-0.8.0 local/
+
+FROM debian:buster-slim
+COPY --from=builder /deps/local/ /deps/local/
+RUN ln -s /deps/local/zig /usr/bin/zig
 
 WORKDIR /opt/app
 COPY . .


### PR DESCRIPTION
This pulls in the Dockerfile for Zig/solution_1 as it was added with PlummersSoftwareLLC/Primes#754. This should address the issues we're now running into with getting PlummersSoftwareLLC/Primes#753 ready for merge.